### PR TITLE
Fix the issue caused by different http versions on server and client

### DIFF
--- a/share/tunnel/tunnel_in_proxy.go
+++ b/share/tunnel/tunnel_in_proxy.go
@@ -104,6 +104,7 @@ func (p *Proxy) runTCP(ctx context.Context) error {
 }
 
 func (p *Proxy) runHTTPS(ctx context.Context) error {
+	p.tlsConf.NextProtos = []string{"http/1.1"}
 	p.https = tls.NewListener(p.tcp, p.tlsConf)
 	p.Infof("Done setting up certs and listener https listener on %s", p.tcp.Addr().String())
 


### PR DESCRIPTION
This change is only required on the chiSSL server side and not the client. 

This PR addresses the issue where chiSSL exposes an HTTP server capable of HTTP2 requests while the local server expects HTTP 1.1. 

This will make sure chiSSL defaults to HTTP1.1